### PR TITLE
Feature/subclasstype

### DIFF
--- a/pytoxml/pytoxml.py
+++ b/pytoxml/pytoxml.py
@@ -1,3 +1,6 @@
+from types import (DictType, StringTypes, IntType, FloatType,
+                   TupleType, ListType)
+
 from lxml import etree
 
 
@@ -22,24 +25,24 @@ class PyToXml(object):
         """Loop over the structure, convert to an etree style document
         and apply to document. The argument name is the element name
         of the parent."""
-        if type(structure) in [basestring, str, unicode]:
+        if isinstance(structure, StringTypes):
             document.text = structure
 
-        elif type(structure) == list:
+        elif isinstance(structure, (ListType, TupleType)):
             for value in structure:
                 sub = etree.SubElement(document, self.pluralisation(name))
                 self.traverse(value, sub, name)
 
-        elif type(structure) == dict:
+        elif isinstance(structure, DictType):
             for key, value in structure.iteritems():
                 sub = etree.SubElement(document, key)
                 self.traverse(value, sub, key)
 
-        elif type(structure) in [int, float]:
-            document.text = str(structure)
-
         elif type(structure) == bool:
             document.text = str(structure).lower()
+
+        elif isinstance(structure, (IntType, FloatType)):
+            document.text = str(structure)
 
         else:
             raise TypeError("Can't serialise %s" % type(structure))

--- a/test/test_pytoxml.py
+++ b/test/test_pytoxml.py
@@ -32,6 +32,15 @@ class TestPyToXml(unittest.TestCase):
         p2x.encode()
         self.assertEqual(str(p2x), "<root><a><b>c</b></a></root>")
 
+    def test_sublclassed_dict_values(self):
+        class MyDict(dict):
+            pass
+        mydict = MyDict()
+        mydict["a"] = { "b": "c" }
+        p2x = PyToXml("root", mydict)
+        p2x.encode()
+        self.assertEqual(str(p2x), "<root><a><b>c</b></a></root>")
+
     def test_list_values(self):
         p2x = PyToXml("root", { "a": [1, 2] })
         p2x.encode()

--- a/test/test_pytoxml.py
+++ b/test/test_pytoxml.py
@@ -48,6 +48,13 @@ class TestPyToXml(unittest.TestCase):
         output = "<root><a><item>1</item><item>2</item></a></root>"
         self.assertEqual(str(p2x), output)
 
+    def test_tuple_values(self):
+        p2x = PyToXml("root", { "a": (1, 2) })
+        p2x.encode()
+
+        output = "<root><a><item>1</item><item>2</item></a></root>"
+        self.assertEqual(str(p2x), output)
+
     def test_unicode(self):
         p2x = PyToXml("root", { "a": u"\u2603" })
         p2x.encode()


### PR DESCRIPTION
Using isinstance to check types allows subclassed types like ordered dict to be used. Will be used full when we want the xml ordered.
